### PR TITLE
Include requirements.txt in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+recursive-include data *

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
     ],
     packages=find_packages(),
     include_package_data=True,
-    package_data={
-    },
+    package_data={},
     install_requires=install_requires,
 )


### PR DESCRIPTION
The [sdist](https://pypi.python.org/packages/2f/db/3d0607d7741da38c745395cca2ffb33e9369f5149ba7db52541a74509785/python-cafe-sqlalchemy-0.4.0.tar.gz#md5=357224c5dbdca3d6e8070046c38bc6eb) on PYPI doesn't contain `requirements.txt`, but `setup.py` requires it to be present. This PR adds a `MANIFEST.in` that will include `requirements.txt` into the sdist package.

Another good idea would be to enable [universal wheels](https://packaging.python.org/distributing/#universal-wheels), assuming that the lib is single-source compatible with both Python 2 and 3.