### PR TITLE
Add args and kwargs to engine method signature.

### DIFF
--- a/cafe/database/sqlalchemy/session.py
+++ b/cafe/database/sqlalchemy/session.py
@@ -47,9 +47,9 @@ class SQLAlchemySessionManager(SessionManager):
         return sessionmaker(bind=engine, **kwargs)
 
     @classmethod
-    def engine(cls):
+    def engine(cls, *args, **kwargs):
         if cls.ENGINE is None:
-            cls.ENGINE = cls.get_engine()
+            cls.ENGINE = cls.get_engine(*args, **kwargs)
         return cls.ENGINE
 
     @abstractclassmethod


### PR DESCRIPTION
Allow for args and kwargs to be passed to get_engine so that non-default behaviour is also accounted for.